### PR TITLE
Add Cloud Composer specific articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This section contains articles that apply to Cloud Composer - a service built by
 
 - [https://medium.com/traveloka-engineering/enabling-autoscaling-in-google-cloud-composer-ac84d3ddd60](Enabling Autoscaling in Google Cloud Composer) - Supercharge your Cloud Composer deployment while saving up some cost on idle period
 - [https://cloud.google.com/blog/products/data-analytics/scale-your-composer-environment-together-your-business]() - The Celery Executor architecture and ways to ensure high scheduler performance.
-- [pianka.sh] - Missing command in the cloud applicaation. This tool facilitates some administrative tasks.
+- [pianka.sh](https://gist.github.com/mik-laj/fd2bbae8e06050cef15ea88d5b6c9b28) - Missing command in the cloud applicaation. This tool facilitates some administrative tasks.
 
 
 ## Non-English resources

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This is a curated list of resources about [Apache Airflow](https://airflow.apach
 - [Qubole](http://docs.qubole.com/en/latest/user-guide/airflow/) - Qubole is mainly known as a service-and-support company for Apache Hive, but also provides Airflow as a component of its platform.
 - [Astronomer.io](https://www.astronomer.io/) - Astronomer provides complete ETL lifecycle solutions and appears to be entirely focused on providing Airflow-based products.
 
-##  Cloud Compose resources
+## Cloud Compose resources
 
 This section contains articles that apply to Cloud Composer - a service built by Google Cloud based on Apache Airlfow. Tricks and solutions are described here that are intended for Cloud Composer, but may be applicable to vanilllaa Airflow
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a curated list of resources about [Apache Airflow](https://airflow.apach
 - [Libraries, Hooks, Utilities](#libraries-hooks-utilities)
 - [Meetups](#meetups)
 - [Commercial Airflow-as-a-service providers](#commercial-airflow-as-a-service-providers)
+- [Cloud Composer resources](#cloud-composer-resources)
 - [Non-English resources](#non-english-resources)
 
 ## Vital links
@@ -161,8 +162,8 @@ This is a curated list of resources about [Apache Airflow](https://airflow.apach
 
 This section contains articles that apply to [Cloud Composer](https://cloud.google.com/composer) - a service built by Google Cloud based on Apache Airflow. Tricks and solutions are described here that are intended for Cloud Composer, but may be applicable to vanilla Airflow.
 
-- [https://medium.com/traveloka-engineering/enabling-autoscaling-in-google-cloud-composer-ac84d3ddd60](Enabling Autoscaling in Google Cloud Composer) - Supercharge your Cloud Composer deployment while saving up some cost on idle period
-- [https://cloud.google.com/blog/products/data-analytics/scale-your-composer-environment-together-your-business](Scale your Composer environment together with your business) - The Celery Executor architecture and ways to ensure high scheduler performance.
+- [Enabling Autoscaling in Google Cloud Composer](https://medium.com/traveloka-engineering/enabling-autoscaling-in-google-cloud-composer-ac84d3ddd60) - Supercharge your Cloud Composer deployment while saving up some cost on idle period
+- [Scale your Composer environment together with your business](https://cloud.google.com/blog/products/data-analytics/scale-your-composer-environment-together-your-business) - The Celery Executor architecture and ways to ensure high scheduler performance.
 - [pianka.sh](https://gist.github.com/mik-laj/fd2bbae8e06050cef15ea88d5b6c9b28) - Missing command in the cloud application. This tool facilitates some administrative tasks.
 
 ## Non-English resources

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ This is a curated list of resources about [Apache Airflow](https://airflow.apach
 
 ## Cloud Composer resources
 
-This section contains articles that apply to Cloud Composer - a service built by Google Cloud based on Apache Airlfow. Tricks and solutions are described here that are intended for Cloud Composer, but may be applicable to vanilllaa Airflow
+This section contains articles that apply to Cloud Composer - a service built by Google Cloud based on Apache Airlfow. Tricks and solutions are described here that are intended for Cloud Composer, but may be applicable to vanilla Airflow
 
 - [https://medium.com/traveloka-engineering/enabling-autoscaling-in-google-cloud-composer-ac84d3ddd60](Enabling Autoscaling in Google Cloud Composer) - Supercharge your Cloud Composer deployment while saving up some cost on idle period
 - [https://cloud.google.com/blog/products/data-analytics/scale-your-composer-environment-together-your-business]() - The Celery Executor architecture and ways to ensure high scheduler performance.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ This is a curated list of resources about [Apache Airflow](https://airflow.apach
 - [Qubole](http://docs.qubole.com/en/latest/user-guide/airflow/) - Qubole is mainly known as a service-and-support company for Apache Hive, but also provides Airflow as a component of its platform.
 - [Astronomer.io](https://www.astronomer.io/) - Astronomer provides complete ETL lifecycle solutions and appears to be entirely focused on providing Airflow-based products.
 
+## Related to Cloud Composer
+
+This section contains articles that apply to Cloud Composer - a service built by Google Cloud based on Apache Airlfow. Tricks and solutions are described here that are intended for Cloud Composer, but may be applicable to vanilllaa Airflow
+
+- [https://medium.com/traveloka-engineering/enabling-autoscaling-in-google-cloud-composer-ac84d3ddd60](Enabling Autoscaling in Google Cloud Composer) - Supercharge your Cloud Composer deployment while saving up some cost on idle period
+- [https://cloud.google.com/blog/products/data-analytics/scale-your-composer-environment-together-your-business]() - The Celery Executor architecture and ways to ensure high scheduler performance.
+- [pianka.sh] - Missing command in the cloud applicaation. This tool facilitates some administrative tasks.
+
+
 ## Non-English resources
 - [Airflow Documentation-Chinese](https://airflow.apachecn.org) - (🇨🇳Chinese) [Apachecn](https://github.com/apachecn) has translated the Airflow official documentation.
 - [Gestion de Tâches avec Apache Airflow](http://ncrocfer.github.io/posts/gestion-de-taches-avec-apache-airflow/) - (🇫🇷French) [Nicolas Crocfer](https://github.com/ncrocfer) - Overview of Airflow, basic concepts and how to write and trigger a DAG.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This is a curated list of resources about [Apache Airflow](https://airflow.apach
 - [Qubole](http://docs.qubole.com/en/latest/user-guide/airflow/) - Qubole is mainly known as a service-and-support company for Apache Hive, but also provides Airflow as a component of its platform.
 - [Astronomer.io](https://www.astronomer.io/) - Astronomer provides complete ETL lifecycle solutions and appears to be entirely focused on providing Airflow-based products.
 
-## Related to Cloud Composer
+##  Cloud Compose resources
 
 This section contains articles that apply to Cloud Composer - a service built by Google Cloud based on Apache Airlfow. Tricks and solutions are described here that are intended for Cloud Composer, but may be applicable to vanilllaa Airflow
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This section contains articles that apply to Cloud Composer - a service built by
 
 - [https://medium.com/traveloka-engineering/enabling-autoscaling-in-google-cloud-composer-ac84d3ddd60](Enabling Autoscaling in Google Cloud Composer) - Supercharge your Cloud Composer deployment while saving up some cost on idle period
 - [https://cloud.google.com/blog/products/data-analytics/scale-your-composer-environment-together-your-business]() - The Celery Executor architecture and ways to ensure high scheduler performance.
-- [pianka.sh](https://gist.github.com/mik-laj/fd2bbae8e06050cef15ea88d5b6c9b28) - Missing command in the cloud applicaation. This tool facilitates some administrative tasks.
+- [pianka.sh](https://gist.github.com/mik-laj/fd2bbae8e06050cef15ea88d5b6c9b28) - Missing command in the cloud application. This tool facilitates some administrative tasks.
 
 
 ## Non-English resources

--- a/README.md
+++ b/README.md
@@ -159,12 +159,11 @@ This is a curated list of resources about [Apache Airflow](https://airflow.apach
 
 ## Cloud Composer resources
 
-This section contains articles that apply to Cloud Composer - a service built by Google Cloud based on Apache Airlfow. Tricks and solutions are described here that are intended for Cloud Composer, but may be applicable to vanilla Airflow
+This section contains articles that apply to [Cloud Composer](https://cloud.google.com/composer) - a service built by Google Cloud based on Apache Airflow. Tricks and solutions are described here that are intended for Cloud Composer, but may be applicable to vanilla Airflow.
 
 - [https://medium.com/traveloka-engineering/enabling-autoscaling-in-google-cloud-composer-ac84d3ddd60](Enabling Autoscaling in Google Cloud Composer) - Supercharge your Cloud Composer deployment while saving up some cost on idle period
-- [https://cloud.google.com/blog/products/data-analytics/scale-your-composer-environment-together-your-business]() - The Celery Executor architecture and ways to ensure high scheduler performance.
+- [https://cloud.google.com/blog/products/data-analytics/scale-your-composer-environment-together-your-business](Scale your Composer environment together with your business) - The Celery Executor architecture and ways to ensure high scheduler performance.
 - [pianka.sh](https://gist.github.com/mik-laj/fd2bbae8e06050cef15ea88d5b6c9b28) - Missing command in the cloud application. This tool facilitates some administrative tasks.
-
 
 ## Non-English resources
 - [Airflow Documentation-Chinese](https://airflow.apachecn.org) - (🇨🇳Chinese) [Apachecn](https://github.com/apachecn) has translated the Airflow official documentation.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ This is a curated list of resources about [Apache Airflow](https://airflow.apach
 
 This section contains articles that apply to [Cloud Composer](https://cloud.google.com/composer) - a service built by Google Cloud based on Apache Airflow. Tricks and solutions are described here that are intended for Cloud Composer, but may be applicable to vanilla Airflow.
 
-- [Enabling Autoscaling in Google Cloud Composer](https://medium.com/traveloka-engineering/enabling-autoscaling-in-google-cloud-composer-ac84d3ddd60) - Supercharge your Cloud Composer deployment while saving up some cost on idle period
+- [Enabling Autoscaling in Google Cloud Composer](https://medium.com/traveloka-engineering/enabling-autoscaling-in-google-cloud-composer-ac84d3ddd60) - Supercharge your Cloud Composer deployment while saving up some cost during idle periods.
 - [Scale your Composer environment together with your business](https://cloud.google.com/blog/products/data-analytics/scale-your-composer-environment-together-your-business) - The Celery Executor architecture and ways to ensure high scheduler performance.
 - [pianka.sh](https://gist.github.com/mik-laj/fd2bbae8e06050cef15ea88d5b6c9b28) - Missing command in the cloud application. This tool facilitates some administrative tasks.
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This is a curated list of resources about [Apache Airflow](https://airflow.apach
 - [Qubole](http://docs.qubole.com/en/latest/user-guide/airflow/) - Qubole is mainly known as a service-and-support company for Apache Hive, but also provides Airflow as a component of its platform.
 - [Astronomer.io](https://www.astronomer.io/) - Astronomer provides complete ETL lifecycle solutions and appears to be entirely focused on providing Airflow-based products.
 
-## Cloud Compose resources
+## Cloud Composer resources
 
 This section contains articles that apply to Cloud Composer - a service built by Google Cloud based on Apache Airlfow. Tricks and solutions are described here that are intended for Cloud Composer, but may be applicable to vanilllaa Airflow
 


### PR DESCRIPTION
hello,

Cloud Composer users are a growing group of Airflow users. Solutions and articles are created that are intended only for them. Some articles, although valuable, were not added to this awesome list because I had doubts whether they could be added to it because they are closely related to the paid Cloud Composer service. However, I thought about what the Apache Foundation would do and I think that would allow it to refer to articles of a commercial nature. The Apache Foundation is not opposed to using the foundation's solutions in commercial services. It is even the opposite. Commercial support allows the development of the Apache products both directly - employees of the company contribute to the product, as well as indirect - facilitate reaching new users.

However, we should make sure that the descriptions of the articles are accurate and objective. They should not promote services, but describe their content.

For me, the community is very important, but Cloud Composer users are also part of the Airflow community.

Best regards,
Kamil Breguła