### PR TITLE
Add Airflow Repository Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This is a curated list of resources about [Apache Airflow](https://airflow.apach
 - [Introducing KEDA for Airflow](https://www.astronomer.io/blog/the-keda-autoscaler/) - How to use KEDA scaler system to enable autoscaling of celery workers based on data stored in the Airflow metadata database.
 
 ## Introductions and tutorials
+- [Airflow Repository Template](https://github.com/soggycactus/airflow-repo-template) - A boilerplate repository for developing locally with Airflow, with linting & tests for valid DAGs and plugins. Just clone and run `make start-airflow` to get started! Add some CI jobs to deploy your code and you're done!
 - [Automate AWS Tasks Thanks to Airflow Hooks](https://blog.sicara.com/automate-aws-tasks-boto3-airflow-hooks-593c3120e8fc) - A step by step tutorial to understand how to connect your Airflow pipeline to S3.
 - [How Apache Airflow Distributes Jobs on Celery workers](https://blog.sicara.com/using-airflow-with-celery-workers-54cb5212d405) - A short description of the steps taken by a task instance, from scheduling to success, in a distributed architecture.
 - [Remote spark-submit to YARN running on EMR](https://medium.com/@tamizhgeek/remote-spark-submit-toyarn-running-on-emr-9804b89d82d2) - [Azhaguselvan](https://github.com/tamizhgeek) walks through submitting Spark jobs to existing EMR clusters with Airflow.


### PR DESCRIPTION
I've now worked on 4 different Airflow installations in my data engineering career, and I keep a template of a boilerplate codebase for developing locally with Airflow - the template is used to kickstart an Airflow codebase that is then deployed to where-ever Airflow lives (EC2, K8s, Astronomer, Composer, etc.)

I figured I'd share my template as I've gotten good feedback about it! You can literally clone the template and run `make start-airflow` to get Airflow up and running locally. The repo also comes with linting (pylint and black) and unit testing for valid DAGs and plugins already baked in. Simply add your DAGs and additional pip dependencies, some CI jobs to deploy and you're done!

EDIT: I should post the actual repo so you can review and decide if it's worthy: https://github.com/soggycactus/airflow-repo-template