### PR TITLE
Add item to Sample projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ or see the individual talks here:*
 
 - [Google Cloud Platform Public Datasets Pipelines](https://github.com/GoogleCloudPlatform/public-datasets-pipelines) - Cloud-native, data pipeline architecture for onboarding datasets to the Google Cloud Public Datasets Program.
 - [GitLab Data Team DAGs](https://gitlab.com/gitlab-data/analytics/-/tree/master/dags) - Several DAGs used to build analytics for the GitLab platform.
+- [deploy-airflow-on-ecs-fargate](https://github.com/hankehly/deploy-airflow-on-ecs-fargate) - Deploy to Amazon ECS Fargate. Demonstrates various features and configurations, such as autoscaling workers to zero, S3 remote logging and secret management.
 
 ## License
 


### PR DESCRIPTION
I created a [sample project](https://github.com/hankehly/deploy-airflow-on-ecs-fargate) demonstrating deployment to Elastic Container Service (ECS). It covers various use cases, including but not limited to:

- autoscale workers to zero
- route logs to CloudWatch or Kinesis Firehose using fluentbit
- use remote_logging to put/get task logs to S3
- use the AWS provider SecretsManagerBackend to store/consume sensitive configuration options in SecretsManager
- run a single command as standalone ECS task (eg. airflow db init)
- get a shell into a running container via ECS exec
- send Airflow statsd metrics to CloudWatch