### PR TITLE
Add airflow-provider-unirate

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ or see the individual talks here:*
 
 ## Libraries, Hooks, Utilities
 - [airflow-provider-shopsavvy](https://github.com/shopsavvy/airflow-provider-shopsavvy) - Apache Airflow provider package for [ShopSavvy](https://shopsavvy.com/) with operators, hooks, and sensors for product price data ETL pipelines.
+- [airflow-provider-unirate](https://github.com/UniRate-API/airflow-provider-unirate) - Apache Airflow provider package for [UniRateAPI](https://unirateapi.com/) with hooks, operators, and a rate-change sensor for real-time and historical currency exchange rates.
 - [Domino](https://github.com/Tauffer-Consulting/domino) - Domino is an open source Graphical User Interface platform for creating data and Machine Learning workflows (DAGs) with no-code, visually intuitive drag-and-drop actions. It is also a standard for publishing and sharing your Python code so it can be automatically used by anyone, directly in the GUI.
 - [Airflow-Helper](https://github.com/xnuinside/airflow-helper) - setting up Airflow Variables, Connections, and Pools from a YAML configuration file.
 - [AirFly](https://github.com/ryanchao2012/airfly) - Auto generate Airflow's dag.py on the fly.


### PR DESCRIPTION
Adds [airflow-provider-unirate](https://github.com/UniRate-API/airflow-provider-unirate) to the Libraries, Hooks, Utilities section.

An Apache Airflow provider package for [UniRateAPI](https://unirateapi.com/) — currency-exchange rates. Ships:

- `UniRateHook` (custom `unirate` connection type)
- `UniRateGetRateOperator` and `UniRateConvertOperator` for latest or historical FX rates
- `UniRateRateChangeSensor` that pokes until an FX pair moves beyond a `threshold_pct` / `abs_threshold` (with optional direction filter), defaulting to `mode="reschedule"`

CI matrix on Apache Airflow 2.10, 2.11, and 3.0 across Python 3.9–3.12. MIT licensed.

> Disclosure: I'm affiliated with UniRateAPI; this package was prepared with assistance from an AI coding agent.
