### PR TITLE
Adds dlt (data load tool) to the Libraries, Hooks, Utilities section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ or see the individual talks here:*
 - [airflow-priority](https://github.com/airflow-laminar/airflow-priority) - Priority Tags (P1, P2, etc) for Airflow DAGs with automated alerting to Datadog, New Relic, Slack, Discord, and more
 - [airflow-config](https://github.com/airflow-laminar/airflow-config) - [Pydantic](https://pydantic.dev) / [Hydra](https://hydra.cc) based configuration system for DAG and Task arguments
 - [airflow-supervisor](https://github.com/airflow-laminar/airflow-supervisor) - Easy-to-use [supervisor](http://supervisord.org) integration for long running or "always on" DAGs
+- [dlt](https://github.com/dlt-hub/dlt) - [data load tool](https://dlthub.com/) is an open-source Python library for building data pipelines with schema inference and incremental loading. Includes an [Airflow helper](https://dlthub.com/docs/walkthroughs/deploy-a-pipeline/deploy-with-airflow-composer) to convert dlt pipelines into Airflow DAGs/TaskGroups.
 
 ## Meetups
 - [Amsterdam Apache Airflow Meetup](https://www.meetup.com/Amsterdam-Airflow-meetup)


### PR DESCRIPTION
dlt is an open-source Python library for building data pipelines with schema inference and incremental loading. It includes an Airflow helper that converts dlt pipelines into Airflow DAGs/TaskGroups.

- dlt: https://github.com/dlt-hub/dlt
- Airflow helper docs: https://dlthub.com/docs/walkthroughs/deploy-a-pipeline/deploy-with-airflow-composer